### PR TITLE
Add /healthz endpint for container healthcheck

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -44,10 +44,6 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/bambulabs-exporter
 
-      - uses: actions/setup-go@v3
-        with:
-          go-version: '^1.20'
-
       - name: Build and push docker image
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -1,0 +1,59 @@
+name: Build Docker Image
+env:
+  TARGET_PLATFORMS: linux/amd64,linux/arm64
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+on:
+  pull_request: {}
+  push:
+    branches:
+      - 'main'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout repository
+        with:
+          submodules: true
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          install: true
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate docker metadata
+        id: image-meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/bambulabs-exporter
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '^1.20'
+
+      - name: Build and push docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: Dockerfile
+          platforms: ${{ env.TARGET_PLATFORMS }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.image-meta.outputs.tags }}
+          labels: ${{ steps.image-meta.outputs.labels }}

--- a/main.go
+++ b/main.go
@@ -398,9 +398,9 @@ func main() {
 	bambulabs := newBambulabsCollector()
 	prometheus.MustRegister(bambulabs)
 	http.HandleFunc("/", home)
+	http.HandleFunc("/healthz", healthz)
 	http.Handle("/metrics", promhttp.Handler())
 	log.Fatal(http.ListenAndServe(":9101", nil))
-
 }
 
 const body = `<html><head><title>BambuLabs Exporter Metrics</title></head><body>
@@ -409,6 +409,11 @@ const body = `<html><head><title>BambuLabs Exporter Metrics</title></head><body>
 
 func home(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, body)
+}
+
+func healthz(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintf(w, "OK")
 }
 
 func newTLSConfig() *tls.Config {


### PR DESCRIPTION
This PR depends on #13 and adds a /healthz endpoint which returns `200 OK` when the app is up and available.

This can later be expanded to include checks for actual container readiness as opposed to liveness status. 